### PR TITLE
Enable UDP communication between termux csound-mode and csound app

### DIFF
--- a/csound-mode.el
+++ b/csound-mode.el
@@ -68,7 +68,11 @@
 (defun csound-play ()
   "Play the csound file in current buffer."
   (interactive)
-  (compile (format "csound -odac %s" (buffer-file-name))))
+  (if csound-repl-start-server-p
+      (compile (format "csound -odac %s" (buffer-file-name)))
+    (process-send-string csound-repl--udp-client-proc
+                         (buffer-substring
+                          (point-min) (point-max)))))
 
 (defun csound-render (bit filename)
   "Render csound to file."
@@ -79,44 +83,49 @@
   ;;(compile (format "csound -o %s" (buffer-file-name)))
   ;; (message "var1: %s var2: %s" var1 var2)
   (let ((filename (if (string= "" filename)
-		      (concat (file-name-base) ".wav")
-		    filename)))
-    (compile (format "csound %s -o %s --format=%s %s"
-		     (buffer-file-name)
-		     filename 
-		     (-> (split-string filename "\\.")
-			 rest first)
-		     (case bit
-		       ("32" "-f")
-		       ("24" "-3")
-		       (t "-s"))))))
+		                  (concat (file-name-base) ".wav")
+		                filename)))
+    (if csound-repl-start-server-p
+        (compile (format "csound %s -o %s --format=%s %s"
+		                     (buffer-file-name)
+		                     filename
+		                     (-> (split-string filename "\\.")
+			                       rest first)
+		                     (case bit
+		                       ("32" "-f")
+		                       ("24" "-3")
+		                       (t "-s"))))
+      (message "%s" "You did not start a csound server subprocess. 
+           Configure rendering to a file in you CSD file's 
+           <CsOptions> section." ))))
 
 
 (defun csound-repl-start ()
   "Start the csound-repl."
   (interactive)
-  (if (executable-find "csound")
-      (csound-repl--buffer-create)
-    (error "Csound is not installed on your computer")))
+  (if (and csound-repl-start-server-p
+           (not (executable-find "csound")))
+      (error "Csound is not installed on your computer")
+    (csound-repl--buffer-create))
 
-(defvar csound-mode-map nil)
+  (defvar csound-mode-map nil))
 
 (setq csound-mode-map
       (let ((map (make-sparse-keymap)))
-	;; Offline keybindings
-	(define-key map (kbd "C-c C-p") 'csound-play)
-	(define-key map (kbd "C-c C-r") 'csound-render) 
-	;; REPL Keybindings
-	(define-key map (kbd "C-c C-z") 'csound-repl-start)
-	(define-key map (kbd "C-M-x")   'csound-repl-evaluate-region)
-	(define-key map (kbd "C-c C-c") 'csound-repl-evaluate-region)
-	(define-key map (kbd "C-x C-e") 'csound-repl-evaluate-line)
-	(define-key map (kbd "C-c C-l") 'csound-repl-interaction-evaluate-last-expression)
-	;; Utilities
-	(define-key map (kbd "C-c C-s") 'csound-score-align-block)
-	(define-key map (kbd "M-.")     'csound-score-find-instr-def)
-	;; (define-key map (kbd "C-c C-f") 'csound-repl-plot-ftgen)
-	map))
+	      ;; Offline keybindings
+	      (define-key map (kbd "C-c C-p") 'csound-play)
+	      (define-key map (kbd "C-c C-r") 'csound-render) 
+	      ;; REPL Keybindings
+	      (define-key map (kbd "C-c C-z") 'csound-repl-start)
+	      (define-key map (kbd "C-M-x")   'csound-repl-evaluate-region)
+	      (define-key map (kbd "C-c C-c") 'csound-repl-evaluate-region)
+	      (define-key map (kbd "C-x C-e") 'csound-repl-evaluate-line)
+	      (define-key map (kbd "C-c C-l") 'csound-repl-interaction-evaluate-last-expression)
+	      ;; Utilities
+	      (define-key map (kbd "C-c C-s") 'csound-score-align-block)
+	    (define-key map (kbd "M-.")     'csound-score-find-instr-def)
+	    ;; (define-key map (kbd "C-c C-f") 'csound-repl-plot-ftgen)
+	    map))
 
 ;;;###autoload
 (define-derived-mode csound-mode

--- a/csound-repl.el
+++ b/csound-repl.el
@@ -147,7 +147,7 @@
 	           (switch-to-prev-buffer)
 	           sr))
          (number-to-string csound-repl-nchnls))
-        (buf "2")))
+        ((number-to-string csound-repl-nchnls))))
 
 (defun csound-repl-buffer-running-p ()
   (let ((indx 0)

--- a/csound-repl.el
+++ b/csound-repl.el
@@ -5,7 +5,7 @@
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.0
 ;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1"))
-;; URL: https://github.com/hlolli/csound-mode
+;; URL: https:/github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -58,13 +58,13 @@
   :group 'csound-mode-repl
   :type 'integer)
 
-(defcustom csound-repl-kr 750000
-  "kr value of the csound repl"
+(defcustom csound-repl-ksmps 32
+  "ksmps value of the csound repl"
   :group 'csound-mode-repl
   :type 'integer)
 
-(defcustom csound-repl-ksmps 32
-  "ksmps value of the csound repl"
+(defcustom csound-repl-kr csound-repl-ksmps
+  "kr value of the csound repl"
   :group 'csound-mode-repl
   :type 'integer)
 
@@ -79,7 +79,7 @@
   :type 'integer)
 
 (defcustom csound-repl-start-server-p t
-  "When non nil, start csound server." 
+  "When non nil, start csound server."
   :group 'csound-mode-repl
   :type 'boolean)
 
@@ -87,78 +87,78 @@
   (cond
    ((and buf csound-repl-start-server-p)
     (save-excursion
-	    (switch-to-buffer buf)
-	    (beginning-of-buffer)
-	    (search-forward-regexp "^\\s-*sr\\s-*=\\s-*\\([0-9]+\\)" nil t 1)
-	    (let ((sr (match-string-no-properties 1)))
-	      (switch-to-prev-buffer)
-	      sr))
+      (switch-to-buffer buf)
+      (beginning-of-buffer)
+      (search-forward-regexp
+       "^\\s-*sr\\s-*=\\s-*\\([0-9]+\\)" nil t 1)
+      (let ((sr (match-string-no-properties 1)))
+        (switch-to-prev-buffer)
+        sr))
     (number-to-string csound-repl-sr))
    (buf (number-to-string csound-repl-sr))))
- 
 
 (defun csound-repl--get-kr (buf)
   (cond ((and buf csound-repl-start-server-p)
          (save-excursion
-	         (switch-to-buffer buf)
-	         (beginning-of-buffer)
-	         (search-forward-regexp
+           (switch-to-buffer buf)
+           (beginning-of-buffer)
+           (search-forward-regexp
             "^\\s-*kr\\s-*=\\s-*\\([0-9]+\\)" nil t 1)
-	         (let ((sr (match-string-no-properties 1)))
-	           (switch-to-prev-buffer)
-	           sr))
+           (let ((sr (match-string-no-properties 1)))
+             (switch-to-prev-buffer)
+             sr))
          (number-to-string csound-repl-kr))
         (buf (number-to-string csound-repl-kr))))
 
 (defun csound-repl--get-ksmps (buf)
   (cond ((and buf csound-repl-start-server-p)
          (save-excursion
-	         (switch-to-buffer buf)
-	         (beginning-of-buffer)
-	         (search-forward-regexp
+           (switch-to-buffer buf)
+           (beginning-of-buffer)
+           (search-forward-regexp
             "^\\s-*ksmps\\s-*=\\s-*\\([0-9]+\\)" nil t 1)
-	         (let ((sr (match-string-no-properties 1)))
-	           (switch-to-prev-buffer)
-	           sr))
+           (let ((sr (match-string-no-properties 1)))
+             (switch-to-prev-buffer)
+             sr))
          (number-to-string csound-repl-ksmps))
-        (buf "64")))
+        (buf (number-to-string csound-repl-ksmps))))
 
 (defun csound-repl--get-0dbfs (buf)
   (cond ((and buf csound-repl-start-server-p)
          (save-excursion
-	         (switch-to-buffer buf)
-	         (beginning-of-buffer)
-	         (search-forward-regexp
+           (switch-to-buffer buf)
+           (beginning-of-buffer)
+           (search-forward-regexp
             "^\\s-*0dbfs\\s-*=\\s-*\\([0-9]+\\)" nil t 1)
-	         (let ((sr (match-string-no-properties 1)))
-	           (switch-to-prev-buffer)
-	           sr))
+           (let ((sr (match-string-no-properties 1)))
+             (switch-to-prev-buffer)
+             sr))
          (number-to-string csound-repl-0dbfs))
         (buf (number-to-string csound-repl-0dbfs))))
 
 (defun csound-repl--get-nchnls (buf)
   (cond ((and buf csound-repl-start-server-p)
          (save-excursion
-	         (switch-to-buffer buf)
-	         (beginning-of-buffer)
-	         (search-forward-regexp
+           (switch-to-buffer buf)
+           (beginning-of-buffer)
+           (search-forward-regexp
             "^\\s-*nchnls\\s-*=\\s-*\\([0-9]+\\)" nil t 1)
-	         (let ((sr (match-string-no-properties 1)))
-	           (switch-to-prev-buffer)
-	           sr))
+           (let ((sr (match-string-no-properties 1)))
+             (switch-to-prev-buffer)
+             sr))
          (number-to-string csound-repl-nchnls))
-        ((number-to-string csound-repl-nchnls))))
+        (buf (number-to-string csound-repl-nchnls))))
 
 (defun csound-repl-buffer-running-p ()
   (let ((indx 0)
-	(exists? nil))
+  (exists? nil))
     (while (and (< indx (length (buffer-list)))
-		(not exists?))
+    (not exists?))
       (if (string-match
-	   csound-repl-buffer-name
-	   (buffer-name (nth indx (buffer-list))))
-	  (setq exists? t)
-	(setq indx (1+ indx))))
+     csound-repl-buffer-name
+     (buffer-name (nth indx (buffer-list))))
+    (setq exists? t)
+  (setq indx (1+ indx))))
     exists?))
 
 (defun csound-repl--buffer-create ()
@@ -166,34 +166,34 @@
   (when (not (csound-repl-buffer-running-p))
     (let ((prev-buffer (buffer-name)))
       (save-excursion
-	(generate-new-buffer
-	 csound-repl-buffer-name)
-	(split-window-sensibly)
-	(switch-to-buffer-other-window csound-repl-buffer-name)
-	(with-current-buffer (buffer-name) (funcall 'csound-repl-mode))
-	(switch-to-buffer-other-window prev-buffer)))))
+  (generate-new-buffer
+   csound-repl-buffer-name)
+  (split-window-sensibly)
+  (switch-to-buffer-other-window csound-repl-buffer-name)
+  (with-current-buffer (buffer-name) (funcall 'csound-repl-mode))
+  (switch-to-buffer-other-window prev-buffer)))))
 
 (defun csound-repl-last-visited-csd ()
   "This decides which filename is given to repl buffer.
    Returns a list of (path buffer-name buffer)"
   (shut-up
     (let ((indx--last-visited 0)
-	  (match-p nil)
-	  (last-file "not-found")
-	  (len (length (buffer-list))))
+    (match-p nil)
+    (last-file "not-found")
+    (len (length (buffer-list))))
       (while (and (< indx--last-visited len)
-		  (not match-p))
-	(if (string-match-p ".csd$" (buffer-name (nth indx--last-visited (buffer-list))))
-	    (prog2
-		(setq-local last-file (list
-				       (file-name-directory
-					(buffer-file-name
-					 (nth indx--last-visited (buffer-list))))
-				       (buffer-name
-					(nth indx--last-visited (buffer-list)))
-				       (nth indx--last-visited (buffer-list)))) 
-		(setq-local match-p t))
-	  (setq-local indx--last-visited (1+ indx--last-visited))))
+      (not match-p))
+  (if (string-match-p ".csd$" (buffer-name (nth indx--last-visited (buffer-list))))
+      (prog2
+    (setq-local last-file (list
+               (file-name-directory
+          (buffer-file-name
+           (nth indx--last-visited (buffer-list))))
+               (buffer-name
+          (nth indx--last-visited (buffer-list)))
+               (nth indx--last-visited (buffer-list))))
+    (setq-local match-p t))
+    (setq-local indx--last-visited (1+ indx--last-visited))))
       last-file)))
 
 
@@ -210,13 +210,13 @@
 (defun csound-repl--input-sender (proc input)
   (unless (eq 0 (length (csound-util-chomp input)))
     (let* ((id (csound-util--generate-random-uuid))
-	   (buffer-read-only nil)
-	   (lb (- (line-beginning-position) 5))
-	   (input-string (-> input csound-util-chomp))
-	   (first-chunk (first (split-string input-string))))
+     (buffer-read-only nil)
+     (lb (- (line-beginning-position) 5))
+     (input-string (-> input csound-util-chomp))
+     (first-chunk (first (split-string input-string))))
       (when (and first-chunk (< 0 (length first-chunk)))
-	(read-csound-repl (intern (substring-no-properties first-chunk 0 1))
-			  csound-repl--udp-client-proc input-string))
+  (read-csound-repl (intern (substring-no-properties first-chunk 0 1))
+        csound-repl--udp-client-proc input-string))
       ;; (comint-output-filter proc (format "%s\n" return-val))
       (push (cons id input) csound-repl--input)
       ;; (message "%s" input)
@@ -227,60 +227,60 @@
 
 (defun csound-repl--generate-welcome-message (cur-file sr ksmps nchnls 0dbfs)
   (let* ((csound-repl---welcome-title
-	  (concat "  __   __   __             __             __   __   __ \n"
-		  " /    /    /  | /  | /| ||/  |      /|/| /  ||/  | /   \n"
-		  "(    (___ (   |(   |( | ||   | ___ ( / |(   ||   |(___ \n"
-		  "|   )    )|   )|   )| | )|   )     |   )|   )|   )|    \n"
-		  "|__/  __/ |__/ |__/ | |/ |__/      |  / |__/ |__/ |__  \n"))
-	 (s (format (concat "\n"
-			    "file: " cur-file "\n"
-			    "sr: %s\n"
-			    "ksmps: %s\n"
-			    "nchnls: %s\n"
-			    "0dbfs: %s\n\n\n")
-		    sr
-		    ksmps
-		    nchnls
-		    0dbfs)))
+    (concat "  __   __   __             __             __   __   __ \n"
+      " /    /    /  | /  | /| ||/  |      /|/| /  ||/  | /   \n"
+      "(    (___ (   |(   |( | ||   | ___ ( / |(   ||   |(___ \n"
+      "|   )    )|   )|   )| | )|   )     |   )|   )|   )|    \n"
+      "|__/  __/ |__/ |__/ | |/ |__/      |  / |__/ |__/ |__  \n"))
+   (s (format (concat "\n"
+          "file: " cur-file "\n"
+          "sr: %s\n"
+          "ksmps: %s\n"
+          "nchnls: %s\n"
+          "0dbfs: %s\n\n\n")
+        sr
+        ksmps
+        nchnls
+        0dbfs)))
     (concat csound-repl---welcome-title s)))
 
 (defun csound-repl--set-default-dir-options ()
   (let ((filedir (nth 1 (csound-repl-last-visited-csd))))
     (mapc (lambda (opt)
-	    (csoundSetOption csound-repl--csound-instance
-			     (format "--env:%s+=;%s"
-				     opt filedir)))
-	  '("INCDIR" "SFDIR"
-	    "SSDIR" "SADIR"
-	    "MFDIR"))))
+      (csoundSetOption csound-repl--csound-instance
+           (format "--env:%s+=;%s"
+             opt filedir)))
+    '("INCDIR" "SFDIR"
+      "SSDIR" "SADIR"
+      "MFDIR"))))
 
 (defun csound-repl--expression-at-point ()
-  (save-excursion 
+  (save-excursion
     (end-of-line)
     (let ((fallback (list (line-beginning-position) (line-end-position)))
-	  (beg (search-backward-regexp "^\\s-*\\<instr\\>\\|^\\s-*\\<opcode\\>" nil t))
-	  (end (search-forward-regexp "^\\s-*\\<endin\\>\\|^\\s-*\\<endop\\>" nil t)))
+    (beg (search-backward-regexp "^\\s-*\\<instr\\>\\|^\\s-*\\<opcode\\>" nil t))
+    (end (search-forward-regexp "^\\s-*\\<endin\\>\\|^\\s-*\\<endop\\>" nil t)))
       (if (and beg end (<= beg (first fallback) end))
-	  (list beg end)
-	fallback
-	;; (throw 'no-expression "No instrument or opcode expression was found.")
-	))))
+    (list beg end)
+  fallback
+  ;; (throw 'no-expression "No instrument or opcode expression was found.")
+  ))))
 
 (defun csound-repl--newline-seperated-score-block ()
   (let ((beg-block (save-excursion
-		     (end-of-line 0)
-		     (while (search-backward-regexp
-			     "\\(^\\s-*\\|^\\t-*\\)i+[0-9\\\".*]*\\b"
-			     (line-beginning-position 1) t 1)
-		       (end-of-line 0))
-		     (line-beginning-position 2)))
-	(end-block (save-excursion
-		     (end-of-line 1)
-		     (while (search-backward-regexp
-			     "\\(^\\s-*\\|^\\t-*\\)i+[0-9\\\".*]*\\b"
-			     (line-beginning-position 1) t 1)
-		       (end-of-line 2))
-		     (line-end-position 0))))
+         (end-of-line 0)
+         (while (search-backward-regexp
+           "\\(^\\s-*\\|^\\t-*\\)i+[0-9\\\".*]*\\b"
+           (line-beginning-position 1) t 1)
+           (end-of-line 0))
+         (line-beginning-position 2)))
+  (end-block (save-excursion
+         (end-of-line 1)
+         (while (search-backward-regexp
+           "\\(^\\s-*\\|^\\t-*\\)i+[0-9\\\".*]*\\b"
+           (line-beginning-position 1) t 1)
+           (end-of-line 2))
+         (line-end-position 0))))
     (list beg-block end-block)))
 
 (setq csound-repl--filter-multline-hackfix nil)
@@ -292,40 +292,40 @@
     (set-buffer csound-repl-buffer-name)
     (goto-char (buffer-size))
     (let ((msg (->> msg
-		    (replace-regexp-in-string "\0\\|\n" "")
-		    (replace-regexp-in-string ">>>" " >>> ")
-		    (replace-regexp-in-string "\\s-+rtevent:\\s-+" "rtevent: ")))
-	  (hackfix-p csound-repl--filter-multline-hackfix))
+        (replace-regexp-in-string "\0\\|\n" "")
+        (replace-regexp-in-string ">>>" " >>> ")
+        (replace-regexp-in-string "\\s-+rtevent:\\s-+" "rtevent: ")))
+    (hackfix-p csound-repl--filter-multline-hackfix))
       (when (string-match-p "rtevent:" msg)
-	(setq csound-repl--filter-multline-hackfix-rtevent 0
-	      csound-repl--filter-multline-hackfix t))
+  (setq csound-repl--filter-multline-hackfix-rtevent 0
+        csound-repl--filter-multline-hackfix t))
       (when (numberp csound-repl--filter-multline-hackfix-rtevent)
-	(if (eq 2 csound-repl--filter-multline-hackfix-rtevent)
-	    (setq csound-repl--filter-multline-hackfix-rtevent nil
-		  csound-repl--filter-multline-hackfix nil)
-	  (setq csound-repl--filter-multline-hackfix-rtevent
-		(1+ csound-repl--filter-multline-hackfix-rtevent))))
+  (if (eq 2 csound-repl--filter-multline-hackfix-rtevent)
+      (setq csound-repl--filter-multline-hackfix-rtevent nil
+      csound-repl--filter-multline-hackfix nil)
+    (setq csound-repl--filter-multline-hackfix-rtevent
+    (1+ csound-repl--filter-multline-hackfix-rtevent))))
       (when (string-match-p ">>>" msg)
-	(setq csound-repl--filter-multline-hackfix t))
+  (setq csound-repl--filter-multline-hackfix t))
       (when (string-match-p "<<<" msg)
-	(setq csound-repl--filter-multline-hackfix nil))
+  (setq csound-repl--filter-multline-hackfix nil))
       (if (prog2 (beginning-of-line)
-	      (search-forward csound-repl-prompt nil t 1))
-	  (progn 
-	    (beginning-of-line)
-	    (end-of-line 0)
-	    (if hackfix-p
-		(insert msg)
-	      (insert (concat "\n" msg))))
-	(progn 
-	  (goto-char (buffer-size))
-	  (end-of-line 1)
-	  (if hackfix-p
-	      (insert msg)
-	    (insert (concat msg "\n")))))
+        (search-forward csound-repl-prompt nil t 1))
+    (progn
+      (beginning-of-line)
+      (end-of-line 0)
+      (if hackfix-p
+    (insert msg)
+        (insert (concat "\n" msg))))
+  (progn
+    (goto-char (buffer-size))
+    (end-of-line 1)
+    (if hackfix-p
+        (insert msg)
+      (insert (concat msg "\n")))))
       (when (or (string-match-p  "rtjack\\: error" msg)
-		(string-match-p "rtjack\\: could not connect" msg))
-	(insert "REPL ERROR: Something went wrong, please restart the repl to continue.\n")))
+    (string-match-p "rtjack\\: could not connect" msg))
+  (insert "REPL ERROR: Something went wrong, please restart the repl to continue.\n")))
     (goto-char (1+ (buffer-size)))))
 
 (defun csound-repl--errorp (pre-eval-size)
@@ -334,9 +334,9 @@
     (goto-char pre-eval-size)
     (beginning-of-line 0)
     (if (or (search-forward-regexp "error: " nil t 1)
-	    (search-forward-regexp "Can't open" nil t 1)
-	    (search-forward-regexp "Can't find" nil t 1))
-	t nil)))
+      (search-forward-regexp "Can't open" nil t 1)
+      (search-forward-regexp "Can't find" nil t 1))
+  t nil)))
 
 (defun csound-repl--flash-region (errorp)
   (if errorp
@@ -348,52 +348,52 @@
      csound-repl--expression-end
      'csound-font-lock-eval-flash))
   (run-with-idle-timer 0.15 nil
-		       (lambda ()
-			 (hlt-unhighlight-region
-			  csound-repl--expression-start
-			  csound-repl--expression-end))))
+           (lambda ()
+       (hlt-unhighlight-region
+        csound-repl--expression-start
+        csound-repl--expression-end))))
 
 (defun csound-repl-evaluate-orchestra-region (start end)
   (let ((expression-string (buffer-substring start end)))
     (setq-local csound-repl--expression-start start)
     (setq-local csound-repl--expression-end end)
     (setq-local csound-repl--expression-tmp-buffer-size
-		(buffer-size (get-buffer csound-repl-buffer-name)))
+    (buffer-size (get-buffer csound-repl-buffer-name)))
     (process-send-string csound-repl--udp-client-proc expression-string)
     (run-with-idle-timer
      0.02 nil
      (lambda ()
        (if (csound-repl--errorp csound-repl--expression-tmp-buffer-size)
-	   (csound-repl--flash-region t) 
-	 (progn
-	   (csound-repl--flash-region nil)
-	   (csound-repl--filter
-	    nil
-	    (concat ";; Evaluated: "
-		    (buffer-substring csound-repl--expression-start
-				      (save-excursion
-					(goto-char csound-repl--expression-start)
-					(line-end-position)))))))))))
+     (csound-repl--flash-region t)
+   (progn
+     (csound-repl--flash-region nil)
+     (csound-repl--filter
+      nil
+      (concat ";; Evaluated: "
+        (buffer-substring csound-repl--expression-start
+              (save-excursion
+          (goto-char csound-repl--expression-start)
+          (line-end-position)))))))))))
 
 
 (defun csound-repl-evaluate-score-region (start end)
   (let ((expression-string (buffer-substring start end))
-	(message-buffer-size (buffer-size
-			      (get-buffer csound-repl-buffer-name))))
+  (message-buffer-size (buffer-size
+            (get-buffer csound-repl-buffer-name))))
     ;; (message expression-string)
     (setq-local csound-repl--expression-start start)
     (setq-local csound-repl--expression-end end)
     (setq-local csound-repl--expression-tmp-buffer-size
-		(buffer-size (get-buffer csound-repl-buffer-name)))
+    (buffer-size (get-buffer csound-repl-buffer-name)))
     (process-send-string csound-repl--udp-client-proc
-			 (concat "$" (csound-score-trim-time expression-string)))
+       (concat "$" (csound-score-trim-time expression-string)))
     (run-with-idle-timer
      0.02 nil
      (lambda ()
        (if (csound-repl--errorp csound-repl--expression-tmp-buffer-size)
-	   (prog2 (csound-repl--flash-region t)
-	       (csound-repl--filter nil ";; Score: error in code"))
-	 (csound-repl--flash-region nil))))))
+     (prog2 (csound-repl--flash-region t)
+         (csound-repl--filter nil ";; Score: error in code"))
+   (csound-repl--flash-region nil))))))
 
 (defun csound-repl-evaluate-region ()
   "Evaluate any csound code in region."
@@ -401,28 +401,28 @@
   (if (not (csound-repl-buffer-running-p))
       (message "csound-repl is not started")
     (if (save-excursion
-	  (search-backward "<CsScore" nil t 1))
-	(if (region-active-p)
-	    (prog2
-		(csound-repl-evaluate-score-region
-		 (region-beginning)
-		 (region-end))
-		(deactivate-mark))
-	  (if (save-excursion
-		(beginning-of-line 1)
-		(search-forward-regexp "i[0-9\"]?" (line-end-position) t 1))
-	      (apply 'csound-repl-evaluate-score-region
-		     (csound-repl--newline-seperated-score-block))
-	    (csound-repl-evaluate-score-region
-	     (line-beginning-position)
-	     (line-end-position))))
+    (search-backward "<CsScore" nil t 1))
+  (if (region-active-p)
+      (prog2
+    (csound-repl-evaluate-score-region
+     (region-beginning)
+     (region-end))
+    (deactivate-mark))
+    (if (save-excursion
+    (beginning-of-line 1)
+    (search-forward-regexp "i[0-9\"]?" (line-end-position) t 1))
+        (apply 'csound-repl-evaluate-score-region
+         (csound-repl--newline-seperated-score-block))
+      (csound-repl-evaluate-score-region
+       (line-beginning-position)
+       (line-end-position))))
       (if (region-active-p)
-	  (prog2
-	      (csound-repl-evaluate-orchestra-region
-	       (region-beginning)
-	       (region-end))
-	      (deactivate-mark))
-	(apply 'csound-repl-evaluate-orchestra-region (csound-repl--expression-at-point))))))
+    (prog2
+        (csound-repl-evaluate-orchestra-region
+         (region-beginning)
+         (region-end))
+        (deactivate-mark))
+  (apply 'csound-repl-evaluate-orchestra-region (csound-repl--expression-at-point))))))
 
 (defun csound-repl-evaluate-line ()
   "Evaluate csound expression on current line."
@@ -430,10 +430,10 @@
   (if (not (csound-repl-buffer-running-p))
       (message "csound-repl is not started")
     (if (save-excursion
-	  (search-backward-regexp "<CsScore" nil t 1))
-	(csound-repl-evaluate-score-region
-	 (line-beginning-position)
-	 (line-end-position))	
+    (search-backward-regexp "<CsScore" nil t 1))
+  (csound-repl-evaluate-score-region
+   (line-beginning-position)
+   (line-end-position))
       (csound-repl-evaluate-orchestra-region
        (line-beginning-position)
        (line-end-position)))))
@@ -446,31 +446,31 @@
 ;;    the png into the REPL."
 ;;   ;; (interactive)
 ;;   (let* ((line-str (buffer-substring-no-properties (line-beginning-position)
-;; 						   (line-end-position)))
-;; 	 (line-str (csound-util-chomp line-str))
-;; 	 (f-statement-p (if (eq 0 (length line-str))
-;; 			    nil
-;; 			  (string-equal "f" (substring line-str 0 1))))
-;; 	 (ftgen-orc-p (string-match-p "\\<ftgen\\>" line-str)))
+;;               (line-end-position)))
+;;   (line-str (csound-util-chomp line-str))
+;;   (f-statement-p (if (eq 0 (length line-str))
+;;          nil
+;;        (string-equal "f" (substring line-str 0 1))))
+;;   (ftgen-orc-p (string-match-p "\\<ftgen\\>" line-str)))
 ;;     (when (or f-statement-p
-;; 	      ftgen-orc-p)
+;;        ftgen-orc-p)
 ;;       (if f-statement-p
-;; 	  (csound-repl-evaluate-score-region (line-beginning-position)
-;; 					     (line-end-position))
-;; 	(csound-repl-evaluate-orchestra-region (line-beginning-position)
-;; 					       (line-end-position)))
+;;    (csound-repl-evaluate-score-region (line-beginning-position)
+;;               (line-end-position))
+;;  (csound-repl-evaluate-orchestra-region (line-beginning-position)
+;;                 (line-end-position)))
 ;;       (sleep-for 0 50)
 ;;       (let ((table-num (if f-statement-p
-;; 			   (-> (substring line-str 1)
-;; 			       (csound-util-chomp)
-;; 			       (split-string " ")
-;; 			       first)
-;; 			 (save-current-buffer
-;; 			   (set-buffer csound-repl-buffer-name)
-;; 			   (goto-char (buffer-size))
-;; 			   (search-backward-regexp "ftable \\([0-9]+\\)\\:")
-;; 			   (match-string-no-properties 1)))))
-;; 	(csound-repl-interaction--plot (string-to-number table-num))))))
+;;         (-> (substring line-str 1)
+;;             (csound-util-chomp)
+;;             (split-string " ")
+;;             first)
+;;       (save-current-buffer
+;;         (set-buffer csound-repl-buffer-name)
+;;         (goto-char (buffer-size))
+;;         (search-backward-regexp "ftable \\([0-9]+\\)\\:")
+;;         (match-string-no-properties 1)))))
+;;  (csound-repl-interaction--plot (string-to-number table-num))))))
 
 (defvar csound-repl--font-lock-list
   '((";.*" . font-lock-comment-face)
@@ -486,46 +486,46 @@
 
 (defun csound-repl--start-client (port)
   (let ((port (if (stringp port) port (number-to-string port)))
-	(host "127.0.0.1"))
+  (host "127.0.0.1"))
     (make-network-process :name "csound-udp-client"
-			  :type 'datagram
-			  :buffer csound-repl-buffer-name
-			  :family 'ipv4
-			  :host host
-			  :service port
-			  :sentinel 'csound-repl--filter
-			  :filter 'csound-repl--filter)))
+        :type 'datagram
+        :buffer csound-repl-buffer-name
+        :family 'ipv4
+        :host host
+        :service port
+        :sentinel 'csound-repl--filter
+        :filter 'csound-repl--filter)))
 
 (defun csound-repl--console-client (port)
   (let ((port (if (stringp port) port (number-to-string port)))
-	(host "127.0.0.1"))
+  (host "127.0.0.1"))
     (make-network-process :name "csound-console-client"
-			  :server t
-			  :type 'datagram
-			  :buffer csound-repl-buffer-name
-			  :family 'ipv4
-			  :host host
-			  :service port
-			  :sentinel 'csound-repl--filter
-			  :filter 'csound-repl--filter)))
+        :server t
+        :type 'datagram
+        :buffer csound-repl-buffer-name
+        :family 'ipv4
+        :host host
+        :service port
+        :sentinel 'csound-repl--filter
+        :filter 'csound-repl--filter)))
 
 (defun csound-repl--start-server (port console-port sr ksmps nchnls zero-db-fs)
   (start-process "Csound Server" csound-repl-buffer-name
-		 "csound" "-odac"
-		 (format "--port=%s" port)
-		 (format "--udp-console=127.0.0.1:%s" console-port)
-		 (format "--sample-rate=%s" sr)
-		 (format "--ksmps=%s" ksmps)
-		 (format "--nchnls=%s" nchnls)
-		 (format "--0dbfs=%s" zero-db-fs)))
+     "csound" "-odac"
+     (format "--port=%s" port)
+     (format "--udp-console=127.0.0.1:%s" console-port)
+     (format "--sample-rate=%s" sr)
+     (format "--ksmps=%s" ksmps)
+     (format "--nchnls=%s" nchnls)
+     (format "--0dbfs=%s" zero-db-fs)))
 
 (setq csound-repl-map
       (let ((map comint-mode-map))
-	(define-key map (kbd "<S-return>")
-	  (lambda ()
-	    (interactive)
-	    (insert "\n      ")))
-	map))
+  (define-key map (kbd "<S-return>")
+    (lambda ()
+      (interactive)
+      (insert "\n      ")))
+  map))
 
 (define-derived-mode
   csound-repl-mode comint-mode "CsoundRepl"
@@ -535,25 +535,25 @@
   (iimage-mode t)
  (unless (comint-check-proc (current-buffer))
     (let* ((last-csound-buffer (csound-repl-last-visited-csd))
-	   (buffer-name (when last-csound-buffer
-			  (nth 1 last-csound-buffer)))
-	   (buffer (when last-csound-buffer
-		     (nth 2 last-csound-buffer)))
-		 (port (if csound-repl-start-server-p 6000 8099))
+     (buffer-name (and last-csound-buffer (listp last-csound-buffer)
+        (nth 1 last-csound-buffer)))
+     (buffer (and last-csound-buffer (listp last-csound-buffer)
+         (nth 2 last-csound-buffer)))
+     (port (if csound-repl-start-server-p 6000 8099))
      (console-port (if csound-repl-start-server-p 6001 8100))
-	   (sr (csound-repl--get-sr buffer))
-	   (ksmps (csound-repl--get-ksmps buffer))
-	   (nchnls (csound-repl--get-nchnls buffer))
-	   (0dbfs (csound-repl--get-0dbfs buffer)))
+     (sr (csound-repl--get-sr buffer))
+     (ksmps (csound-repl--get-ksmps buffer))
+     (nchnls (csound-repl--get-nchnls buffer))
+     (0dbfs (csound-repl--get-0dbfs buffer)))
       (insert (csound-repl--generate-welcome-message buffer-name sr ksmps nchnls 0dbfs))
       (if csound-repl-start-server-p
           (setq csound-repl--csound-server (csound-repl--start-server
-					                                  port
-					                                  console-port
-					                                  sr
-					                                  ksmps
-					                                  nchnls
-					                                  0dbfs))
+                                            port
+                                            console-port
+                                            sr
+                                            ksmps
+                                            nchnls
+                                            0dbfs))
        (let ((fake-proc
          (condition-case nil
            (start-process "ijsm" (current-buffer) "hexl")
@@ -574,7 +574,7 @@
       (set-process-query-on-exit-flag csound-repl--udp-client-proc nil)
       (set-process-query-on-exit-flag csound-repl--console-client-proc nil)
       (setq-local font-lock-defaults '(csound-font-lock-list
-				       csound-repl--font-lock-list))
+               csound-repl--font-lock-list))
       (setq-local comment-start ";; ")
       (setq-local eldoc-documentation-function 'csound-eldoc-function)
       (add-hook 'completion-at-point-functions #'csound-util-opcode-completion-at-point nil t)


### PR DESCRIPTION
Hi, I now prepared csound-mode in a way that I can successfully run it on Android by using it inside Termux Spacemacs, and communicating via UPD with the Csound Android App.

This is based on two enhancements:

1. I created a "fake process" to keep comint happy
2. I created a new custom variable `csound-repl-start-server-p` which is true by default, but inhibits all references to the Emacs Csound server subprocess when nil. 

`csound-play` and `csound-repl-start` do work, albeit only if inside the Csound Android the UPDlisten.csd has been started and listens at port 8099.

`csound-render` returns a message that output to a file needs to be configured inside the (server) csd file within `<CsOptions>` when no Csound server subprocess has been started in Emacs.

I created a new branch for this, tj-master, but since you only have a master branch, my pull-request goes there. You should test the linux desktop version of csound-mode (setq `csound-repl-start-server-p` t), if I haven't messed up anything. For testing on Android you will need the fantastic termux app.

I made example files work (sound), but due to my beginners ignorance with csound syntax, I could not get "real" example songs play yet. From the examples it looks straightforward, split the song csd file in two files, server and client file so to say, with an `f0` variable inside the server score, and (only) the real score content inside the client file. This works when I trigger client events with `schedule`, but those frequent `i1 ` statements in the example files score do give parser errors. I have to learn more about csound syntax I guess ...

Cheers Thorsten

PS
By the way, this is really a marvelous mode, I'm looking forward to play around with it on my smartphone. If you accept this pull request, another superb thing would be a Spacemacs layer for Csound, since with it's one key menus and bindings, and transient modes, Spacemacs would be a fantastic environment for REPL live coding.

Normally, everything useful for a mode goes into a Spacemacs layer. I have one question wrt to this: there is another impressive Emacs mode for Csound, `csound-x`, why there are two modes, what is their relation? Should both modes complement each other in a Spacemacs layer, or would that be redundant?




 