### PR TITLE
Add auto-mode file recognition to autoload

### DIFF
--- a/csound-mode.el
+++ b/csound-mode.el
@@ -151,7 +151,7 @@
     (with-silent-modifications
       (csound-font-lock--flush-score))))
 
-
+;;;###autoload
 (add-to-list 'auto-mode-alist `(,(concat "\\." (regexp-opt '("csd" "orc" "sco" "udo")) "\\'") . csound-mode))
 
 (provide 'csound-mode)


### PR DESCRIPTION
Without autoloading the file extensions inclusion in auto-mode-alist, emacs does not enable csound-mode when opening a csd/orc/sco/udo file. The alternative would be require-ing 'csound-mode at init, but then why autoload anything at all?