### PR TITLE
Migrate from case to cl-case

### DIFF
--- a/csound-mode.el
+++ b/csound-mode.el
@@ -92,7 +92,7 @@
 		         filename
 		         (-> (split-string filename "\\.")
 			     rest first)
-		         (case bit
+		         (cl-case bit
 		           ("32" "-f")
 		           ("24" "-3")
 		           (t "-s"))))


### PR DESCRIPTION
This is required for compatibility with recent Emacs versions. The unprefixed CL macros are deprecated and not loaded by default.