### PR TITLE
Make font-lock work instantly

### DIFF
--- a/csound-mode.el
+++ b/csound-mode.el
@@ -143,7 +143,6 @@
   (add-hook 'completion-at-point-functions #'csound-util-opcode-completion-at-point nil t)
   ;; (add-hook 'skeleton-end-hook #'csound-font-lock-flush-buffer nil t)
   (font-lock-add-keywords nil csound-font-lock-list t)
-  (setq-local font-lock-fontify-region-function 'csound-font-lock-fontify-region)
   (setq-local font-lock-fontify-buffer-function 'csound-font-lock-flush-buffer)
   (setq-local fontification-functions (cons 'csound-font-lock-flush-buffer fontification-functions))
   (setq-local jit-lock-function 'csound-font-lock-flush-buffer)

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -143,12 +143,6 @@
   (add-hook 'completion-at-point-functions #'csound-util-opcode-completion-at-point nil t)
   ;; (add-hook 'skeleton-end-hook #'csound-font-lock-flush-buffer nil t)
   (font-lock-add-keywords nil csound-font-lock-list t)
-  (setq-local font-lock-fontify-buffer-function 'csound-font-lock-flush-buffer)
-  (setq-local fontification-functions (cons 'csound-font-lock-flush-buffer fontification-functions))
-  (setq-local jit-lock-function 'csound-font-lock-flush-buffer)
-  (setq-local jit-lock-functions '(csound-font-lock-fontify-region))
-  (setq-local jit-lock-mode t)
-  (jit-lock-refontify)
   (shut-up
     (with-silent-modifications
       (csound-font-lock-flush-buffer)


### PR DESCRIPTION
I do not know what the purpose of this setting was, but removing it eliminates a bug which causes syntax highlighting to be nondeterministically delayed, because Emacs is smart enough these days to handle font-lock itself for the most part.