### PR TITLE
Fix ignoring file bit-value by csound-render

### DIFF
--- a/csound-mode.el
+++ b/csound-mode.el
@@ -103,9 +103,9 @@
 		         filename
 		         (-> (split-string filename "\\.")
 			     cl-rest cl-first)
-		         (cl-case bit
-		           ("32" "-f")
-		           ("24" "-3")
+		         (cl-case (string-to-number bit)
+		           (32 "-f")
+		           (24 "-3")
 		           (t "-s"))))
       (message "%s" "You did not start a csound server subprocess.
            Configure rendering to a file in you CSD file's


### PR DESCRIPTION
csound-render can not change file bit-value by the interactive input because cl-case uses eql for matching. Comparing as number does.