### PR TITLE
A few additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ releases
 #clj
 .nrepl-port
 
+
 # devfile
 test.csd

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ releases
 
 # devfile
 test.csd
+
+### MacOS
+
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ as well as a REPL for fast feedback when composing/sound-designing using Csound.
 * Indentation rules
 * Syntax highlighting and rainbow delimited score parameters
 
+## About this fork
+
+This fork implements a few additions to the original code which are suited to the workflow of the author. 
+
 ## Installation
 
-You can install `csound-mode` from `MELPA` using the following command:
-
-<kbd>M-x package-install [RET] csound-mode [RET]</kbd>
+It is recommended to install the package manually, e.g. by pulling the code into the `.emacs.d` folder and adding the following lines to your Emacs init-file.
 
 Alternatively, [download latest release.](https://github.com/hlolli/csound-mode/releases/download/v9.2.0/csound-mode-0.2.0.zip)
 and add it manually to load-path like shown here:
@@ -29,6 +31,7 @@ and add it manually to load-path like shown here:
 (add-to-list 'load-path "~/.emacs.d/csound-mode/")
 (require 'csound-mode)
 ```
+
 
 ## Requirements
 
@@ -44,9 +47,9 @@ If you're using `csound-mode` directly from the git repo, and you happen to use 
 ```Clojure
 (use-package csound-mode
   :mode (("\\.csd\\'" . csound-mode)
-  	 ("\\.orc\\'" . csound-mode)
-  	 ("\\.sco\\'" . csound-mode)
-  	 ("\\.udo\\'" . csound-mode))
+     ("\\.orc\\'" . csound-mode)
+     ("\\.sco\\'" . csound-mode)
+     ("\\.udo\\'" . csound-mode))
   :load-path "packages/csound-mode/")
 ```
 
@@ -57,6 +60,8 @@ If you're using `csound-mode` directly from the git repo, and you happen to use 
 
 <kbd>C-c C-z</kbd> `csound-repl-start`
 
+<kbd>C-c C-k</kbd> `csound-abort-compilation` abort compilation (e.g. playback) -- *added with this fork*
+
 <kbd>C-M-x</kbd>/<kbd>C-c C-c</kbd> `csound-evaluate-region`
 
 <kbd>C-x C-e</kbd> `csound-evaluate-line`
@@ -66,6 +71,8 @@ If you're using `csound-mode` directly from the git repo, and you happen to use 
 <kbd>C-c C-s</kbd> `csound-score-align-block` cursor needs to be within a score block
 
 <kbd>M-.</kbd> `csound-score-find-instr-def` cursor needs to be within a score block
+
+<kbd>C-c C-d h</kbd> `csound-manual-lookup` searches for a function definition in the Csound-manual -- *added with this fork*
 
 
 ## Run the tests

--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ as well as a REPL for fast feedback when composing/sound-designing using Csound.
 * Indentation rules
 * Syntax highlighting and rainbow delimited score parameters
 
-## About this fork
-
-This fork implements a few additions to the original code which are suited to the workflow of the author. 
-
 ## Installation
 
-It is recommended to install the package manually, e.g. by pulling the code into the `.emacs.d` folder and adding the following lines to your Emacs init-file.
+You can install `csound-mode` from `MELPA` using the following command:
+
+<kbd>M-x package-install [RET] csound-mode [RET]</kbd>
 
 Alternatively, [download latest release.](https://github.com/hlolli/csound-mode/releases/download/v9.2.0/csound-mode-0.2.0.zip)
 and add it manually to load-path like shown here:
@@ -31,7 +29,6 @@ and add it manually to load-path like shown here:
 (add-to-list 'load-path "~/.emacs.d/csound-mode/")
 (require 'csound-mode)
 ```
-
 
 ## Requirements
 
@@ -60,7 +57,7 @@ If you're using `csound-mode` directly from the git repo, and you happen to use 
 
 <kbd>C-c C-z</kbd> `csound-repl-start`
 
-<kbd>C-c C-k</kbd> `csound-abort-compilation` abort compilation (e.g. playback) -- *added with this fork*
+<kbd>C-c C-k</kbd> `csound-abort-compilation` abort compilation (e.g. playback)
 
 <kbd>C-M-x</kbd>/<kbd>C-c C-c</kbd> `csound-evaluate-region`
 
@@ -72,7 +69,7 @@ If you're using `csound-mode` directly from the git repo, and you happen to use 
 
 <kbd>M-.</kbd> `csound-score-find-instr-def` cursor needs to be within a score block
 
-<kbd>C-c C-d h</kbd> `csound-manual-lookup` searches for a function definition in the Csound-manual -- *added with this fork*
+<kbd>C-c C-d h</kbd> `csound-manual-lookup` searches for a function definition in the Csound-manual
 
 
 ## Run the tests

--- a/csound-manual-lookup.el
+++ b/csound-manual-lookup.el
@@ -31,3 +31,6 @@
 
 (eval-after-load 'csound-mode
   '(define-key csound-mode-map (kbd "C-c C-d h") 'csound-manual-lookup))
+
+
+(provide 'csound-manual-lookup)

--- a/csound-manual-lookup.el
+++ b/csound-manual-lookup.el
@@ -1,3 +1,31 @@
+;;; csound-eldoc.el --- A major mode for interacting and coding Csound
+;;  Copyright (C) 2017 - 2022  Hlöðver Sigurðsson
+
+;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
+;; Version: 0.2.7
+;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; URL: https://github.com/hlolli/csound-mode
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  This module implements Csound manual lookup functionality for 
+;;; csound-mode. 
+
+;;; Code:
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Csound manual lookup
 ;;;
@@ -15,10 +43,12 @@
 ;;; CREATED
 ;;; 2022-12-26, Lütgendortmund
 ;;; 
-;;; $$ Last modified:  23:58:26 Mon Apr 17 2023 CEST
+;;; $$ Last modified:  00:57:30 Wed Apr 26 2023 CEST
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
+(require 'csound-opcodes)
+(require 'csound-util)
+(require 'cl-lib)
 (require 'browse-url)
 (require 'thingatpt)
 

--- a/csound-manual-lookup.el
+++ b/csound-manual-lookup.el
@@ -1,13 +1,21 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Csound manual lookup
 ;;;
-;;; an extension enabling interactive lookup of csound function
-;;; definitions
-;;; Extension to the Emacs Csound-mode
+;;; DESCRIPTION
+;;; This extension enables the interactive lookup of Csound functions in the
+;;; Csound reference manual located at the Csound homepage.
+;;; 
+;;; TODO:
+;;; - Implement a global variable referring to the Csound manual base url.
+;;;   This might be handy e.g. when the manual is installed locally.
 ;;;
-;;; author: Ruben Philipp
-;;; created: 2022-12-26, Lütgendortmund
-;;; $$ Last modified:  21:04:37 Mon Dec 26 2022 CET
+;;; AUTHOR
+;;; Ruben Philipp
+;;;
+;;; CREATED
+;;; 2022-12-26, Lütgendortmund
+;;; 
+;;; $$ Last modified:  23:58:26 Mon Apr 17 2023 CEST
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -18,6 +26,8 @@
 (defun csound-manual-lookup ()
   (interactive)
   (let* ((lemma (thing-at-point 'word 'no-properties))
+         ;;; cf. TODO
+         ;;; RP  Mon Apr 17 23:58:01 2023
          (csound-manual-url "http://www.csounds.com/manual/html/")
          (lookup-lemma (if (gethash lemma
                                     csdoc-opcode-database)
@@ -34,3 +44,6 @@
 
 
 (provide 'csound-manual-lookup)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; EOF csound-manual-lookup.el

--- a/csound-manual-lookup.el
+++ b/csound-manual-lookup.el
@@ -1,0 +1,33 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Csound manual lookup
+;;;
+;;; an extension enabling interactive lookup of csound function
+;;; definitions
+;;; Extension to the Emacs Csound-mode
+;;;
+;;; author: Ruben Philipp
+;;; created: 2022-12-26, Lütgendortmund
+;;; $$ Last modified:  21:04:37 Mon Dec 26 2022 CET
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+(require 'browse-url)
+(require 'thingatpt)
+
+
+(defun csound-manual-lookup ()
+  (interactive)
+  (let* ((lemma (thing-at-point 'word 'no-properties))
+         (csound-manual-url "http://www.csounds.com/manual/html/")
+         (lookup-lemma (if (gethash lemma
+                                    csdoc-opcode-database)
+                           (downcase lemma)
+                         (read-string "Lookup function in Csound manual: "))))
+    (browse-url (concat csound-manual-url
+                        lookup-lemma
+                        ".html"))))
+
+;;; key binding
+
+(eval-after-load 'csound-mode
+  '(define-key csound-mode-map (kbd "C-c C-d h") 'csound-manual-lookup))

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -37,6 +37,7 @@
 (require 'csound-score)
 (require 'csound-skeleton)
 (require 'csound-util)
+(require 'csound-manual-lookup)
 (require 'dash)
 (require 'shut-up)
 

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -6,6 +6,12 @@
 ;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; edited by: Ruben Philipp (me@rubenphilipp.com)
+;;; $$ Last modified:  21:10:07 Mon Dec 26 2022 CET
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -85,6 +91,29 @@
     (process-send-string csound-repl--udp-client-proc
                          (buffer-substring
                           (point-min) (point-max)))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; csound-abort-compilation
+;;;
+;;; author: Ruben Philipp
+;;; created: 2022-12-26, Lütgendortmund
+;;; $$ Last modified:  21:11:15 Mon Dec 26 2022 CET
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun csound-abort-compilation ()
+  (interactive)
+  (let ((current-buffer (current-buffer)))
+    (switch-to-buffer "*compilation*")
+    (kill-compilation)
+    (switch-to-buffer current-buffer)))
+
+(eval-after-load 'csound-mode
+  '(define-key csound-mode-map (kbd "C-c C-k") 'abort-csound-compilation))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 
 (defun csound-render (bit filename)
   "Render csound to file."

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -98,7 +98,7 @@
 ;;;
 ;;; author: Ruben Philipp
 ;;; created: 2022-12-26, Lütgendortmund
-;;; $$ Last modified:  21:11:15 Mon Dec 26 2022 CET
+;;; $$ Last modified:  21:12:50 Mon Dec 26 2022 CET
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun csound-abort-compilation ()
@@ -109,7 +109,7 @@
     (switch-to-buffer current-buffer)))
 
 (eval-after-load 'csound-mode
-  '(define-key csound-mode-map (kbd "C-c C-k") 'abort-csound-compilation))
+  '(define-key csound-mode-map (kbd "C-c C-k") 'csound-abort-compilation))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -8,7 +8,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; edited by: Ruben Philipp (me@rubenphilipp.com)
-;;; $$ Last modified:  21:10:07 Mon Dec 26 2022 CET
+;;; $$ Last modified:  23:52:36 Mon Apr 17 2023 CEST
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -96,9 +96,17 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; csound-abort-compilation
 ;;;
+;;; DESCRIPTION:
+;;; This function aborts the compilation of a Csound file. This is simply
+;;; done by killing the compilation process in the main compilation buffer
+;;; (i.e. *compilation*)
+;;;
+;;; TODO:
+;;; - Make this context-sensitive, in case multiple compilation buffers are
+;;;   active in an Emacs session.
+;;;
 ;;; author: Ruben Philipp
 ;;; created: 2022-12-26, Lütgendortmund
-;;; $$ Last modified:  21:12:50 Mon Dec 26 2022 CET
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun csound-abort-compilation ()

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -6,12 +6,6 @@
 ;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; edited by: Ruben Philipp (me@rubenphilipp.com)
-;;; $$ Last modified:  23:52:36 Mon Apr 17 2023 CEST
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -80,7 +80,7 @@
   "Play the csound file in current buffer."
   (interactive)
   (if csound-repl-start-server-p
-      (compile (format "csound -odac %s %s" csound-play-flags (buffer-file-name)))
+      (compile (format "csound %s %s" csound-play-flags (buffer-file-name)))
     (process-send-string csound-repl--udp-client-proc
                          (buffer-substring
                           (point-min) (point-max)))))
@@ -94,19 +94,19 @@
   ;;(compile (format "csound -o %s" (buffer-file-name)))
   ;; (message "var1: %s var2: %s" var1 var2)
   (let ((filename (if (string= "" filename)
-		      (concat (file-name-base) ".wav")
-		    filename)))
+                      (concat (file-name-base) ".wav")
+                    filename)))
     (if csound-repl-start-server-p
         (compile (format "csound %s %s -o %s --format=%s %s"
-		         csound-render-flags
-		         (buffer-file-name)
-		         filename
-		         (-> (split-string filename "\\.")
-			     cl-rest cl-first)
-		         (cl-case (string-to-number bit)
-		           (32 "-f")
-		           (24 "-3")
-		           (t "-s"))))
+                         csound-render-flags
+                         (buffer-file-name)
+                         filename
+                         (-> (split-string filename "\\.")
+                             cl-rest cl-first)
+                         (cl-case (string-to-number bit)
+                           (32 "-f")
+                           (24 "-3")
+                           (t "-s"))))
       (message "%s" "You did not start a csound server subprocess.
            Configure rendering to a file in you CSD file's
            <CsOptions> section." ))))
@@ -123,20 +123,20 @@
 
 (setq csound-mode-map
       (let ((map (make-sparse-keymap)))
-	;; Offline keybindings
-	(define-key map (kbd "C-c C-p") 'csound-play)
-	(define-key map (kbd "C-c C-r") 'csound-render)
-	;; REPL Keybindings
-	(define-key map (kbd "C-c C-z") 'csound-repl-start)
-	(define-key map (kbd "C-M-x")   'csound-repl-evaluate-region)
-	(define-key map (kbd "C-c C-c") 'csound-repl-evaluate-region)
-	(define-key map (kbd "C-x C-e") 'csound-repl-evaluate-line)
-	(define-key map (kbd "C-c C-l") 'csound-repl-interaction-evaluate-last-expression)
-	;; Utilities
-	(define-key map (kbd "C-c C-s") 'csound-score-align-block)
-	(define-key map (kbd "M-.")     'csound-score-find-instr-def)
-	;; (define-key map (kbd "C-c C-f") 'csound-repl-plot-ftgen)
-	map))
+        ;; Offline keybindings
+        (define-key map (kbd "C-c C-p") 'csound-play)
+        (define-key map (kbd "C-c C-r") 'csound-render)
+        ;; REPL Keybindings
+        (define-key map (kbd "C-c C-z") 'csound-repl-start)
+        (define-key map (kbd "C-M-x")   'csound-repl-evaluate-region)
+        (define-key map (kbd "C-c C-c") 'csound-repl-evaluate-region)
+        (define-key map (kbd "C-x C-e") 'csound-repl-evaluate-line)
+        (define-key map (kbd "C-c C-l") 'csound-repl-interaction-evaluate-last-expression)
+        ;; Utilities
+        (define-key map (kbd "C-c C-s") 'csound-score-align-block)
+        (define-key map (kbd "M-.")     'csound-score-find-instr-def)
+        ;; (define-key map (kbd "C-c C-f") 'csound-repl-plot-ftgen)
+        map))
 
 ;;;###autoload
 (define-derived-mode csound-mode

--- a/csound-skeleton.el
+++ b/csound-skeleton.el
@@ -24,7 +24,7 @@
 ;;  Skeleton for when creating new .csd file.
 
 ;; Initialize defaults values
-(defcustom csound-skeleton-default-sr 48000
+(defcustom csound-skeleton-default-sr 44100
   "Set the default sr value when creating new csound file."
   :type 'integer
   :group 'csound-mode)
@@ -38,7 +38,7 @@
   "Skeleton for auto-insert in csound-mode."
   nil
   "<CsoundSynthesizer>\n"
-  "<CsOptions>\n-f\n</CsOptions>\n"
+  "<CsOptions>\n</CsOptions>\n"
   "<CsInstruments>\n\n"
   (concat "sr = " (number-to-string csound-skeleton-default-sr) "\n")
   (concat "ksmps = " (number-to-string csound-skeleton-default-ksmps) "\n")
@@ -53,9 +53,9 @@
 (eval-when-compile
   (define-auto-insert "\\.csd\\'"
     [csound-skeleton-new-csd (lambda ()
-                               (goto-line 11)
-                               (run-with-idle-timer 0.15 nil
-                                                    (lambda () (csound-font-lock-flush-buffer))))]))
+			       (goto-line 11)
+			       (run-with-idle-timer 0.15 nil
+						    (lambda () (csound-font-lock-flush-buffer))))]))
 
 (provide 'csound-skeleton)
 

--- a/csound-skeleton.el
+++ b/csound-skeleton.el
@@ -24,7 +24,7 @@
 ;;  Skeleton for when creating new .csd file.
 
 ;; Initialize defaults values
-(defcustom csound-skeleton-default-sr 44100
+(defcustom csound-skeleton-default-sr 48000
   "Set the default sr value when creating new csound file."
   :type 'integer
   :group 'csound-mode)
@@ -38,7 +38,7 @@
   "Skeleton for auto-insert in csound-mode."
   nil
   "<CsoundSynthesizer>\n"
-  "<CsOptions>\n</CsOptions>\n"
+  "<CsOptions>\n-f\n</CsOptions>\n"
   "<CsInstruments>\n\n"
   (concat "sr = " (number-to-string csound-skeleton-default-sr) "\n")
   (concat "ksmps = " (number-to-string csound-skeleton-default-ksmps) "\n")
@@ -53,9 +53,9 @@
 (eval-when-compile
   (define-auto-insert "\\.csd\\'"
     [csound-skeleton-new-csd (lambda ()
-			       (goto-line 11)
-			       (run-with-idle-timer 0.15 nil
-						    (lambda () (csound-font-lock-flush-buffer))))]))
+                               (goto-line 11)
+                               (run-with-idle-timer 0.15 nil
+                                                    (lambda () (csound-font-lock-flush-buffer))))]))
 
 (provide 'csound-skeleton)
 


### PR DESCRIPTION
First of all, thanks a lot, Hlöðver, for this mesmerizing work! I am spreading the word of your project amongst my colleagues and receive -- from those within the Emacs universe, of course -- solely eulogistic feedback.

Anyway, I have written some extensions to your mode over the past months. The most important, for me, is the ability to **abort the compilation** of a Csound process with a simple key binding. This is done via the function `csound-abort-compilation` and the respective key-binding. I think this might be handy especially to those who are used to working with Csound-QT or similar environments. 
This leads me to the next, more broad, addition to your package. As it is sometimes useful **to lookup the definition**/reference or some opcode, I have added a module which resembles the SLIME lookup function which opens the documentation of a certain function(/method/macro etc.) from the context of a buffer via, in this case, `C-c C-d h`.

I hope, you will find these additions of some use and might incorporate them via the next commit.

Best regards
Ruben