### PR TITLE
Two improvements of score aligning

### DIFF
--- a/csound-score.el
+++ b/csound-score.el
@@ -152,7 +152,10 @@ parameter are of same space width."
                (line-end-position 1) t 1)
               (setq line-num-test (1+ line-num-test))
             (setq ending-of-block (line-end-position 0)))))
-      (csound-score--align-cols beginning-of-block ending-of-block))))
+      ;; workaround to align string instr name correctly
+      (with-syntax-table (make-syntax-table (syntax-table))
+        (modify-syntax-entry ?\" "w")
+        (csound-score--align-cols beginning-of-block ending-of-block)))))
 
 (defun csound-score-trim-time (score-string)
   (let ((trimmed-string (split-string

--- a/csound-score.el
+++ b/csound-score.el
@@ -41,10 +41,10 @@
       (goto-char start)
       (beginning-of-line)
       (while (< (line-number-at-pos (point))
-                line-end)
+                (1+ line-end))
         (indent-line-to 0)
         (forward-line))
-      (let ((statements (-> (buffer-substring start (line-end-position))
+      (let ((statements (-> (buffer-substring start (line-end-position 0))
                             (substring-no-properties)
                             (split-string "\n"))))
         ;; Create matrix of max lengths


### PR DESCRIPTION
1. Execute `(indent-line-to 0)` also to the last line of score.
2. Work around to align the score including string instr names correctly.