### PR TITLE
miscellaneous improvements of csound-score.el

### DIFF
--- a/csound-score.el
+++ b/csound-score.el
@@ -103,7 +103,10 @@
                   ;; Move to the end of next parameter and get the length
                   (setq param-length
                         (+ ex-length (skip-chars-forward "^[:space:]")))
-                  (setq index (1+ index)))))))))))
+                  (setq index (1+ index))))
+              (if (= (point) (line-end-position))
+                  (setq line-num 0
+                        line-end 0)))))))))
 
 (defun csound-score-align-block ()
   "Align score block so that all parameter are of same space width."
@@ -112,21 +115,21 @@
     (if (save-excursion
           ;; See if point is on an score event line
           (beginning-of-line)
-          (search-forward-regexp re (line-end-position) t))
+          (re-search-forward re (line-end-position) t))
         (let ((beginning-of-block
                (save-excursion
                  ;; Search for beginning of block
-                 (forward-line -1)
-                 (while (search-forward-regexp re (line-end-position) t)
-                   (forward-line -1))
-                 (line-beginning-position 2)))
+                 (beginning-of-line)
+                 (while (re-search-backward re (line-beginning-position 0) t)
+                   (beginning-of-line))
+                 (point)))
               (end-of-block
                (save-excursion
                  ;; Search for end of block
-                 (forward-line)
-                 (while (search-forward-regexp re (line-end-position) t)
-                   (forward-line))
-                 (line-end-position 0))))
+                 (end-of-line)
+                 (while (re-search-forward re (line-end-position 2) t)
+                   (end-of-line))
+                 (point))))
           (csound-score--align-cols beginning-of-block end-of-block)))))
 
 (defun csound-score-trim-time (score-string)

--- a/csound-score.el
+++ b/csound-score.el
@@ -113,22 +113,20 @@
           ;; See if point is on an score event line
           (beginning-of-line)
           (search-forward-regexp re (line-end-position) t))
-        (let ((beginning-of-block)
-              (end-of-block))
-          (save-excursion
-            ;; Search for beginning of block
-            (forward-line -1)
-            (while (not beginning-of-block)
-              (if (search-forward-regexp re (line-end-position) t)
-                  (forward-line -1)
-                (setq beginning-of-block (line-beginning-position 2)))))
-          (save-excursion
-            ;; Search for end of block
-            (forward-line)
-            (while (not end-of-block)
-              (if (search-forward-regexp re (line-end-position) t)
-                  (forward-line)
-                (setq end-of-block (line-end-position 0)))))
+        (let ((beginning-of-block
+               (save-excursion
+                 ;; Search for beginning of block
+                 (forward-line -1)
+                 (while (search-forward-regexp re (line-end-position) t)
+                   (forward-line -1))
+                 (line-beginning-position 2)))
+              (end-of-block
+               (save-excursion
+                 ;; Search for end of block
+                 (forward-line)
+                 (while (search-forward-regexp re (line-end-position) t)
+                   (forward-line))
+                 (line-end-position 0))))
           (csound-score--align-cols beginning-of-block end-of-block)))))
 
 (defun csound-score-trim-time (score-string)

--- a/csound-score.el
+++ b/csound-score.el
@@ -27,7 +27,6 @@
 
 ;;; Code:
 
-(require 'cl-lib)
 (require 'csound-font-lock)
 (require 'csound-util)
 (require 'font-lock)
@@ -98,9 +97,8 @@
                 (delete-char spaces-to-add))
               (if before-comment
                   (forward-line)
-                (progn
-                  (setq param-length (skip-chars-forward "^[:space:]"))
-                  (setq index (1+ index)))))))))))
+                (setq param-length (skip-chars-forward "^[:space:]")
+                      index (1+ index))))))))))
 
 
 (defun csound-score-align-block ()

--- a/csound-score.el
+++ b/csound-score.el
@@ -62,18 +62,19 @@
                   (setq index (1+ index))))))))
       ;; Align the block
       (goto-char start)
-      (while (<= (line-number-at-pos (point)) line-end)
+      (while (<= (line-number-at-pos) line-end)
         ;; Remove indent and add a space before comment
         (indent-line-to 0)
-        (if (re-search-forward ";\\|//" (line-end-position) t)
-            (replace-match " \\&"))
+        (if (and (re-search-forward "\\(.\\)\\(;\\|//\\)" (line-end-position) t)
+                 (save-match-data (string-match "\\S-" (match-string 1))))
+            (replace-match "\\1 \\2"))
         ;; Align the line
         (beginning-of-line)
-        (let* ((line-num (line-number-at-pos (point)))
+        (let* ((line-num (line-number-at-pos))
                ;; Move to the end of next parameter and get the length
                (param-length (skip-chars-forward "^[:space:]"))
                (index 0))
-          (while (= (line-number-at-pos (point)) line-num)
+          (while (= (line-number-at-pos) line-num)
             ;; Align the parameter
             (let* ((margin-length (skip-chars-forward "[:space:]"))
                    (before-comment (or (= (following-char) ?\;)
@@ -84,7 +85,7 @@
                            ;; needed length before comment
                            (let ((subvec (nthcdr index max-matrix)))
                              (+ (apply #'+ subvec) (length subvec) 1))
-                         (if (= (point) (line-end-position))
+                         (if (eolp)
                              ;; needed length before line end
                              param-length
                            ;; needed length before next parameter

--- a/csound-score.el
+++ b/csound-score.el
@@ -65,8 +65,8 @@
       (while (<= (line-number-at-pos (point)) line-end)
         ;; Remove indent and add a space before comment
         (indent-line-to 0)
-        (when (re-search-forward ";\\|//" (line-end-position) t)
-          (replace-match " \\&"))
+        (if (re-search-forward ";\\|//" (line-end-position) t)
+            (replace-match " \\&"))
         ;; Align the line
         (beginning-of-line)
         (let* ((line-num (line-number-at-pos (point)))
@@ -83,7 +83,7 @@
                     (- (if before-comment
                            ;; needed length before comment
                            (let ((subvec (nthcdr index max-matrix)))
-                             (+ (apply '+ subvec) (length subvec) 1))
+                             (+ (apply #'+ subvec) (length subvec) 1))
                          (if (= (point) (line-end-position))
                              ;; needed length before line end
                              param-length
@@ -106,39 +106,39 @@
 parameter are of same space width."
   (interactive)
   ;; See if point is on an score event line
-  (when (save-excursion
-          (progn
-            (beginning-of-line 1)
-            (search-forward-regexp
-             "\\(^\\s-*\\|^\\t-*\\)[if]"
-             (line-end-position 1) t 1)))
-    ;; Search for beginning of block
-    (let ((beginning-of-block nil)
-          (line-num-test 1)
-          (ending-of-line-at-point (line-end-position 1))
-          (beginning-of-line-at-point (line-beginning-position 1))
-          (ending-of-block nil))
-      (save-excursion
-        (while (not (numberp beginning-of-block))
-          (goto-char ending-of-line-at-point)
-          (end-of-line line-num-test)
-          (if (search-backward-regexp
-               "\\(^\\s-*\\|^\\t-*\\)[if]"
-               (line-beginning-position 1) t 1)
-              (setq line-num-test (1- line-num-test))
-            (setq beginning-of-block (line-beginning-position 2)))))
-      (setq line-num-test 1)
-      ;; Search for ending of block
-      (save-excursion
-        (while (not (numberp ending-of-block))
-          (goto-char beginning-of-line-at-point)
-          (beginning-of-line line-num-test)
-          (if (search-forward-regexp
-               "\\(^\\s-*\\|^\\t-*\\)[if]"
-               (line-end-position 1) t 1)
-              (setq line-num-test (1+ line-num-test))
-            (setq ending-of-block (line-end-position 0)))))
-      (csound-score--align-cols beginning-of-block ending-of-block))))
+  (if (save-excursion
+        (progn
+          (beginning-of-line 1)
+          (search-forward-regexp
+           "\\(^\\s-*\\|^\\t-*\\)[if]"
+           (line-end-position 1) t 1)))
+      ;; Search for beginning of block
+      (let ((beginning-of-block nil)
+            (line-num-test 1)
+            (ending-of-line-at-point (line-end-position 1))
+            (beginning-of-line-at-point (line-beginning-position 1))
+            (ending-of-block nil))
+        (save-excursion
+          (while (not (numberp beginning-of-block))
+            (goto-char ending-of-line-at-point)
+            (end-of-line line-num-test)
+            (if (search-backward-regexp
+                 "\\(^\\s-*\\|^\\t-*\\)[if]"
+                 (line-beginning-position 1) t 1)
+                (setq line-num-test (1- line-num-test))
+              (setq beginning-of-block (line-beginning-position 2)))))
+        (setq line-num-test 1)
+        ;; Search for ending of block
+        (save-excursion
+          (while (not (numberp ending-of-block))
+            (goto-char beginning-of-line-at-point)
+            (beginning-of-line line-num-test)
+            (if (search-forward-regexp
+                 "\\(^\\s-*\\|^\\t-*\\)[if]"
+                 (line-end-position 1) t 1)
+                (setq line-num-test (1+ line-num-test))
+              (setq ending-of-block (line-end-position 0)))))
+        (csound-score--align-cols beginning-of-block ending-of-block))))
 
 (defun csound-score-trim-time (score-string)
   (let ((trimmed-string (split-string

--- a/csound-score.el
+++ b/csound-score.el
@@ -70,9 +70,9 @@
                    (save-match-data (string-match "\\S-" (match-string 1))))
             (replace-match "\\1 \\2")))
         ;; Align the line
-        (let* ((line-num (line-number-at-pos))
-               (param-length 0)
-               (index -1))
+        (let ((line-num (line-number-at-pos))
+              (param-length 0)
+              (index -1))
           (while (= (line-number-at-pos) line-num)
             ;; Align the parameter
             (let* ((margin-length (skip-chars-forward "[:space:]"))

--- a/csound-score.el
+++ b/csound-score.el
@@ -108,45 +108,28 @@
 (defun csound-score-align-block ()
   "Align score block so that all parameter are of same space width."
   (interactive)
-  ;; See if point is on an score event line
-  (if (save-excursion
-        (progn
-          (beginning-of-line 1)
-          (search-forward-regexp
-           "\\(^\\s-*\\|^\\t-*\\)[if]"
-           (line-end-position 1) t 1)))
-      ;; Search for beginning of block
-      (let ((beginning-of-block nil)
-            (line-num-test 1)
-            (ending-of-line-at-point (line-end-position 1))
-            (beginning-of-line-at-point (line-beginning-position 1))
-            (ending-of-block nil))
-        (save-excursion
-          (while (not (numberp beginning-of-block))
-            (goto-char ending-of-line-at-point)
-            (end-of-line line-num-test)
-            (if (search-backward-regexp
-                 "\\(^\\s-*\\|^\\t-*\\)[if]"
-                 (line-beginning-position 1) t 1)
-                (setq line-num-test (1- line-num-test))
-              (setq beginning-of-block (line-beginning-position 2)))))
-        (setq line-num-test 1)
-        ;; Search for ending of block
-        (save-excursion
-          (while (not (numberp ending-of-block))
-            (goto-char beginning-of-line-at-point)
-            (beginning-of-line line-num-test)
-            (if (search-forward-regexp
-                 "\\(^\\s-*\\|^\\t-*\\)[if]"
-                 (line-end-position 1) t 1)
-                (setq line-num-test (1+ line-num-test))
-              (setq ending-of-block (line-end-position 0)))))
-        (csound-score--align-cols beginning-of-block ending-of-block))))
-
-(defun csound-score-align-region ()
-  "Align score region so that all parameter are of same space width."
-  (interactive)
-  (csound-score--align-cols (region-beginning) (region-end)))
+  (let ((re "^\\s-*[[:alpha:]$]"))
+    (if (save-excursion
+          ;; See if point is on an score event line
+          (beginning-of-line)
+          (search-forward-regexp re (line-end-position) t))
+        (let ((beginning-of-block)
+              (end-of-block))
+          (save-excursion
+            ;; Search for beginning of block
+            (forward-line -1)
+            (while (not beginning-of-block)
+              (if (search-forward-regexp re (line-end-position) t)
+                  (forward-line -1)
+                (setq beginning-of-block (line-beginning-position 2)))))
+          (save-excursion
+            ;; Search for end of block
+            (forward-line)
+            (while (not end-of-block)
+              (if (search-forward-regexp re (line-end-position) t)
+                  (forward-line)
+                (setq end-of-block (line-end-position 0)))))
+          (csound-score--align-cols beginning-of-block end-of-block)))))
 
 (defun csound-score-trim-time (score-string)
   (let ((trimmed-string (split-string

--- a/csound-score.el
+++ b/csound-score.el
@@ -104,7 +104,8 @@
                   (setq param-length
                         (+ ex-length (skip-chars-forward "^[:space:]")))
                   (setq index (1+ index))))
-              (if (= (point) (line-end-position))
+              ;; Exit loop at buffer end
+              (if (eobp)
                   (setq line-num 0
                         line-end 0)))))))))
 


### PR DESCRIPTION
These are not urgent corrections.
* Not required cl-lib any more for csound-score.el
* Revert "apply '+" to "apply #'+"
* Prevent changing buffer when already aligned
* Enable aligning score including [expression] correctly
  cf. https://csound.com/docs/manual/ScoreEval.html
* Enable 'csound-score-align-block to detect statements other than i and f
  cf. https://csound.com/docs/manual/ScoreStatements.html https://csound.com/docs/manual/ScoreMacros.html
* Enable aligning score even when region to be detected begins at buffer beginning or ends at buffer end (may occur in *.sco)