### PR TITLE
Added features for browsing the manual and gen lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ With more options
 
 <kbd>C-c C-d h</kbd> `csound-manual-lookup` searches for a function definition in the Csound-manual
 
+<kbd>C-c C-d g</kbd> `csound-gen-manual-lookup` searches for a GEN routine in the Csound-manual
+
+<kbd>C-c C-d g</kbd> `csound-browse-manual` opens the Csound-manual index to allow for browsing of opcodes and learning the language
+
+<kbd>C-c C-d g</kbd> `csound-browse-gen-manual` opens the Csound-manual GEN routines to allow for browsing of GEN routines
 
 ## Run the tests
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ With more options
 
 <kbd>C-c C-d g</kbd> `csound-gen-manual-lookup` searches for a GEN routine in the Csound-manual
 
-<kbd>C-c C-d g</kbd> `csound-browse-manual` opens the Csound-manual index to allow for browsing of opcodes and learning the language
+<kbd>C-c m</kbd> `csound-browse-manual` opens the Csound-manual index to allow for browsing of opcodes and learning the language
 
-<kbd>C-c C-d g</kbd> `csound-browse-gen-manual` opens the Csound-manual GEN routines to allow for browsing of GEN routines
+<kbd>C-c g</kbd> `csound-browse-gen-manual` opens the Csound-manual GEN routines to allow for browsing of GEN routines
 
 ## Run the tests
 

--- a/csound-manual-lookup.el
+++ b/csound-manual-lookup.el
@@ -57,9 +57,22 @@
 ;;; Customizing this could be useful e.g. when the manual is
 ;;; installed locally.
 ;;; RP  Wed Sep 20 19:51:22 2023
+;;; Updated by Brandon Hale April 25, 2026
 (defcustom csound-manual-url
   "https://csound.com/docs/manual/"
   "The URL to the root directory of the Csound manual."
+  :group 'csound-mode-manual-lookup
+  :type 'string)
+
+(defcustom csound-browse-manual-url
+  "https://csound.com/docs/manual/index.html"
+  "The URL to the index of the Csound manual, useful for browsing of opcodes and learning the language."
+  :group 'csound-mode-manual-lookup
+  :type 'string)
+
+(defcustom csound-browse-gen-manual-url
+  "https://csound.com/docs/manual/ScoreGenRef.html"
+  "The URL to the GEN routines of the Csound manual, useful for browsing of routines."
   :group 'csound-mode-manual-lookup
   :type 'string)
 
@@ -74,11 +87,32 @@
                         lookup-lemma
                         ".html"))))
 
+(defun csound-gen-manual-lookup ()
+  (interactive)
+  (let* ((cursor-text (thing-at-point 'number 'no-properties))
+	 (user-input (if (not cursor-text)
+			 (read-string "Lookup GEN in Csound manual: ")
+		       (number-to-string cursor-text)))
+	 (use-input (if (= (length user-input) 1)
+			(concat "0" user-input)
+		      user-input)))
+    (browse-url (concat csound-manual-url "GEN" use-input ".html"))))
+
+(defun csound-browse-manual ()
+  (interactive)
+  (browse-url csound-browse-manual-url))
+
+(defun csound-browse-gen-manual ()
+  (interactive)
+  (browse-url csound-browse-gen-manual-url))
+
 ;;; key binding
 
 (eval-after-load 'csound-mode
-  '(define-key csound-mode-map (kbd "C-c C-d h") 'csound-manual-lookup))
-
+  '(define-key csound-mode-map (kbd "C-c C-d h") 'csound-manual-lookup)
+  '(define-key csound-mode-map (kbd "C-c C-d g") 'csound-gen-manual-lookup)
+  '(define-key csound-mode-map (kbd "C-c g") 'csound-browse-gen-manual)
+  '(define-key csound-mode-map (kbd "C-c m") 'csound-browse-manual))
 
 (provide 'csound-manual-lookup)
 

--- a/csound-opcodes.el
+++ b/csound-opcodes.el
@@ -1854,6 +1854,8 @@ kans, kdata[] OSClisten ihandle, idest, itype" :doc "Listen for OSC messages to 
 (puthash "prints" '(:template "prints \"string\" [, kval1] [, kval2] [...]" :doc "Prints at init-time using a printf() style syntax.") csdoc-opcode-database)
 (puthash "printks" '(:template "printks \"string\", itime [, kval1] [,kval2] [...]" :doc "Prints at k-rate using a printf() style syntax.") csdoc-opcode-database)
 (puthash "printks2" '(:template "printks2 \"string\", kval " :doc "Prints a new value every time a control variable changes using a printf() style syntax.") csdoc-opcode-database)
+(puthash "lag" '(:template "aout lag ain, klagtime [, initialvalue=0]
+kout lag kin, klagtime [, initialvalue=0]" :doc "Exponential Lag") csdoc-opcode-database)
 
- (provide 'csound-opcodes)
+(provide 'csound-opcodes)
 ;;; csound-opcodes.el ends here


### PR DESCRIPTION
Added browse manual function, browse gen manual function, and gen lookup function, taking the original documentation code and adding more features, including adding keybindings for the functions.

I've been using these features in my emacs config and really think they add a lot to the workflow and would like others to benefit from them.

EDIT: Also added the lag opcode to allow for hinting