### PR TITLE
chore: update Emacs compatibility metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and add it manually to load-path like shown here:
 
 ## Requirements
 
-- Emacs 25+
+- Emacs 27.1+
 - Csound 6.10+ (any release/compilation after 1. December 2017)
 
 ## Usage

--- a/csound-eldoc.el
+++ b/csound-eldoc.el
@@ -3,7 +3,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/csound-font-lock.el
+++ b/csound-font-lock.el
@@ -3,7 +3,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -28,6 +28,11 @@
 
 (require 'font-lock)
 (require 'csound-opcodes)
+
+(defgroup csound-mode-font-lock nil
+  "Csound font lock."
+  :prefix "csound-font-lock-"
+  :group 'csound-mode)
 
 (defvar csound-font-lock--missing-faces '())
 

--- a/csound-indentation.el
+++ b/csound-indentation.el
@@ -4,7 +4,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/csound-manual-lookup.el
+++ b/csound-manual-lookup.el
@@ -1,9 +1,9 @@
-;;; csound-eldoc.el --- A major mode for interacting and coding Csound
+;;; csound-manual-lookup.el --- Browse the Csound manual
 ;;  Copyright (C) 2017 - 2023  Hlöðver Sigurðsson
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
-;; Version: 0.2.7
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Version: 0.2.9
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -58,14 +58,27 @@
 ;;; installed locally.
 ;;; RP  Wed Sep 20 19:51:22 2023
 ;;; Updated by Brandon Hale April 25, 2026
+(defgroup csound-mode-manual-lookup nil
+  "Csound manual lookup."
+  :prefix "csound-manual-"
+  :group 'csound-mode)
+
 (defcustom csound-manual-url
   "https://csound.com/docs/manual/"
   "The URL to the root directory of the Csound manual."
   :group 'csound-mode-manual-lookup
   :type 'string)
 
-(defun csound-manual-browse (file)
-  (browse-url (file-name-concat csound-manual-url file)))
+(defun csound-manual--file-name-concat (directory filename)
+  "Return FILENAME under DIRECTORY.
+Use `file-name-concat' when available, and fall back to an Emacs 27
+compatible implementation otherwise."
+  (if (fboundp 'file-name-concat)
+      (file-name-concat directory filename)
+    (concat (file-name-as-directory directory) filename)))
+
+(defun csound-manual--browse (file)
+  (browse-url (csound-manual--file-name-concat csound-manual-url file)))
 
 (defun csound-manual-lookup ()
   (interactive)
@@ -74,7 +87,7 @@
                                     csdoc-opcode-database)
                            (downcase lemma)
                          (read-string "Lookup function in Csound manual: "))))
-    (csound-manual-browse (concat lookup-lemma ".html"))))
+    (csound-manual--browse (concat lookup-lemma ".html"))))
 
 (defun csound-gen-manual-lookup ()
   (interactive)
@@ -85,15 +98,15 @@
 	 (use-input (if (= (length user-input) 1)
 			(concat "0" user-input)
 		      user-input)))
-    (csound-manual-browse (concat "GEN" use-input ".html"))))
+    (csound-manual--browse (concat "GEN" use-input ".html"))))
 
 (defun csound-browse-manual ()
   (interactive)
-  (csound-manual-browse "index.html"))
+  (csound-manual--browse "index.html"))
 
 (defun csound-browse-gen-manual ()
   (interactive)
-  (csound-manual-browse "ScoreGenRef.html"))
+  (csound-manual--browse "ScoreGenRef.html"))
 
 ;;; key binding
 

--- a/csound-mode.el
+++ b/csound-mode.el
@@ -3,7 +3,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -43,9 +43,9 @@
 
 
 (defgroup csound-mode nil
-  "Tiny functionality enhancements for evaluating sexps."
+  "Major mode for Csound."
   :prefix "csound-mode-"
-  :group 'csound-mode)
+  :group 'languages)
 
 (defvar csound-mode-syntax-table
   (let ((st (make-syntax-table)))

--- a/csound-opcodes.el
+++ b/csound-opcodes.el
@@ -3,7 +3,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/csound-repl-interaction.el
+++ b/csound-repl-interaction.el
@@ -4,7 +4,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/csound-repl.el
+++ b/csound-repl.el
@@ -4,7 +4,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -34,6 +34,11 @@
 (require 'font-lock)
 (require 'highlight)
 (require 'shut-up)
+
+(defgroup csound-mode-repl nil
+  "Csound REPL."
+  :prefix "csound-repl-"
+  :group 'csound-mode)
 
 (defvar csound-repl--csound-server)
 (defvar csound-repl--udp-client-proc)

--- a/csound-score.el
+++ b/csound-score.el
@@ -4,7 +4,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/csound-skeleton.el
+++ b/csound-skeleton.el
@@ -4,7 +4,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/csound-util.el
+++ b/csound-util.el
@@ -3,7 +3,7 @@
 
 ;; Author: Hlöðver Sigurðsson <hlolli@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
+;; Package-Requires: ((emacs "27.1") (shut-up "0.3.2") (multi "2.0.1") (dash "2.16.0") (highlight "0"))
 ;; URL: https://github.com/hlolli/csound-mode
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Raise the declared minimum Emacs version to 27.1, add a local
compatibility helper for manual URL construction, and clean up package
metadata for MELPA/package-lint style.

Also defines missing custom groups and fixes the manual lookup file header.